### PR TITLE
feat: 瞑想用リアルタイム時計アプリ

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,11 @@ async function requestWakeLock() {
       let lock = await navigator.wakeLock.request('screen');
       document.addEventListener('visibilitychange', async () => {
         if (document.visibilityState === 'visible') {
-          lock = await navigator.wakeLock.request('screen');
+          try {
+            lock = await navigator.wakeLock.request('screen');
+          } catch {
+            // Re-acquire failed
+          }
         }
       });
     }

--- a/app.js
+++ b/app.js
@@ -1,0 +1,34 @@
+export function formatTime(date) {
+  const h = String(date.getHours()).padStart(2, '0');
+  const m = String(date.getMinutes()).padStart(2, '0');
+  const s = String(date.getSeconds()).padStart(2, '0');
+  return `${h}:${m}:${s}`;
+}
+
+function updateClock() {
+  const el = document.getElementById('clock');
+  if (el) {
+    el.textContent = formatTime(new Date());
+  }
+}
+
+async function requestWakeLock() {
+  try {
+    if ('wakeLock' in navigator) {
+      let lock = await navigator.wakeLock.request('screen');
+      document.addEventListener('visibilitychange', async () => {
+        if (document.visibilityState === 'visible') {
+          lock = await navigator.wakeLock.request('screen');
+        }
+      });
+    }
+  } catch {
+    // Wake Lock not supported or denied
+  }
+}
+
+if (typeof document !== 'undefined') {
+  updateClock();
+  setInterval(updateClock, 1000);
+  requestWakeLock();
+}

--- a/app.test.js
+++ b/app.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { formatTime } from './app.js';
+
+describe('formatTime', () => {
+  it('formats a normal time with zero-padding', () => {
+    const date = new Date(2026, 0, 1, 1, 2, 3);
+    expect(formatTime(date)).toBe('01:02:03');
+  });
+
+  it('formats midnight as 00:00:00', () => {
+    const date = new Date(2026, 0, 1, 0, 0, 0);
+    expect(formatTime(date)).toBe('00:00:00');
+  });
+
+  it('formats afternoon time correctly', () => {
+    const date = new Date(2026, 0, 1, 14, 30, 59);
+    expect(formatTime(date)).toBe('14:30:59');
+  });
+
+  it('formats 23:59:59 correctly', () => {
+    const date = new Date(2026, 0, 1, 23, 59, 59);
+    expect(formatTime(date)).toBe('23:59:59');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>瞑想時計</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="clock"></div>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "meditation-clock",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^3.1.1"
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,26 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100dvh;
+  overflow: hidden;
+  cursor: none;
+}
+
+#clock {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: clamp(3rem, 12vw, 10rem);
+  color: rgba(255, 255, 255, 0.85);
+  letter-spacing: 0.05em;
+  user-select: none;
+  text-shadow: 0 0 40px rgba(255, 255, 255, 0.08);
+}


### PR DESCRIPTION
Closes #1

## 概要
画面中央に現在時刻（hh:mm:ss）をリアルタイム表示する瞑想用ウェブアプリ。

## 変更内容
- `app.js` - formatTime()純粋関数 + 毎秒更新ロジック + Screen Wake Lock API
- `index.html` - 最小構成のHTML（viewport meta対応）
- `style.css` - 黒背景ダークテーマ、Share Tech Monoフォント、clamp()レスポンシブ
- `app.test.js` - formatTime()のユニットテスト（4ケース）
- `package.json` - Vitest最小構成

## テスト結果
- 4 tests passed (formatTime: ゼロパディング、深夜、午後、23:59:59)

🤖 Generated with [Claude Code](https://claude.com/claude-code)